### PR TITLE
React cleanup

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import "./App.css";
 import SearchBar from "./components/toolbar/SearchBar";
 import { api } from "./util/api";
-import SortableRow from "./components/list/SortableRow";
+import CraftspersonRow from "./components/list/CraftspersonRow";
 import { sortByNumberOfMentees, sortByCraftspeopleWithoutMentor } from "./util/sorting";
 import { filter } from "./util/filtering";
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar'
@@ -62,7 +62,8 @@ function App() {
                         </ToggleButtonGroup>
                     </ButtonToolbar>
                 </div>
-                {filteredCrafspeople.map(craftsperson => <SortableRow key={craftsperson.id} craftsperson={craftsperson} />)}
+                {filteredCrafspeople.map(craftsperson => 
+                    <CraftspersonRow key={craftsperson.id} craftsperson={craftsperson} />)}
             </div>
         </div>
     );

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -14,6 +14,7 @@ function App() {
     const [craftspeople, setCraftsPeople] = useState([]);
     const [filteredCrafspeople, setFilteredCrafspeople] = useState(craftspeople);
     const [sortAlgorithm, setSortAlgorithm] = useState(() => sortByNumberOfMentees);
+    const [backendFetchError, setBackendFetchError] = useState(null);
 
     function sortWithCurrentAlgorithm(craftspeople) {
         craftspeople.sort(sortAlgorithm);
@@ -47,8 +48,7 @@ function App() {
             })
             .catch(error => {
                 console.log(error);
-                const fixture_data_for_craftspeople = Array.from(FIXTURE);
-                sortAndSetCraftspeople(fixture_data_for_craftspeople);
+                setBackendFetchError(error)
             });
     }, []);
 
@@ -56,6 +56,10 @@ function App() {
         <div className='App'>
             <div>
                 <h1>Mementor</h1>
+                {backendFetchError &&   
+                    <div class="alert alert-danger" role="alert">
+                        <strong>Oh snap!</strong> Looks like there was an error while fetching the data.
+                    </div>}
                 <div className="container">
                     <SearchBar onEnter={filterCraftspeople} />
                     <ButtonToolbar>

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -15,23 +15,28 @@ function App() {
     const [filteredCrafspeople, setFilteredCrafspeople] = useState(craftspeople);
     const [sortAlgorithm, setSortAlgorithm] = useState(() => sortByNumberOfMentees);
 
+    function sortWithCurrentAlgorithm(craftspeople) {
+        craftspeople.sort(sortAlgorithm);
+    }
+
     function filterCraftspeople(searchedValue) {
         const filteredCraftspeople = filter(craftspeople, searchedValue);
-        filteredCraftspeople.sort(sortAlgorithm);
+        sortWithCurrentAlgorithm(filteredCraftspeople);
         setFilteredCrafspeople(filteredCraftspeople);
     };
 
     function sortAndSetCraftspeople(craftspeople) {
-        const sortedCraftspeople = craftspeople.sort(sortAlgorithm)
-        setCraftsPeople(sortedCraftspeople);
-        setFilteredCrafspeople(sortedCraftspeople);
+        sortWithCurrentAlgorithm(craftspeople);
+        setCraftsPeople(craftspeople);
+        setFilteredCrafspeople(craftspeople);
     };
 
     function makeSortOnClickListener (sortAlgorithmToUse) {
         return () => {
             setSortAlgorithm(() => sortAlgorithmToUse);
-            const sortedCraftspeople = filteredCrafspeople.sort(sortAlgorithmToUse);
-            setFilteredCrafspeople(sortedCraftspeople);
+            // here we don't use the current algorithm because it's outdated 
+            filteredCrafspeople.sort(sortAlgorithmToUse);
+            setFilteredCrafspeople(filteredCrafspeople);
         }
     };
 

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -26,7 +26,7 @@ function App() {
         return () => {
             setSortAlgorithm(() => sortAlgorithmToUse);
             // here we don't use the current algorithm because it's outdated 
-            craftspeople.sort(sortAlgorithm);
+            craftspeople.sort(sortAlgorithmToUse);
             filteredCrafspeople.sort(sortAlgorithmToUse);
             setFilteredCrafspeople(filteredCrafspeople);
         }

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -51,7 +51,7 @@ function App() {
     return (
         <div className='App'>
             <div>
-                <Header />
+                <h1>Mementor</h1>
                 <div className="container">
                     <SearchBar onEnter={filterCraftspeople} />
                     <ButtonToolbar>

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -19,7 +19,6 @@ function App() {
 
     function filterCraftspeople(searchedValue) {
         const filteredCraftspeople = filter(craftspeople, searchedValue);
-        craftspeople.sort(sortAlgorithm);
         setFilteredCrafspeople(filteredCraftspeople);
     };
 
@@ -27,6 +26,7 @@ function App() {
         return () => {
             setSortAlgorithm(() => sortAlgorithmToUse);
             // here we don't use the current algorithm because it's outdated 
+            craftspeople.sort(sortAlgorithm);
             filteredCrafspeople.sort(sortAlgorithmToUse);
             setFilteredCrafspeople(filteredCrafspeople);
         }

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -6,7 +6,6 @@ import SortableRow from "./components/list/SortableRow";
 import FIXTURE from "./util/fixture.json";
 import { sortByNumberOfMentees, sortByCraftspeopleWithoutMentor } from "./util/sorting";
 import { filter } from "./util/filtering";
-import Header from "./components/header/Header";
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar'
 import ToggleButton from 'react-bootstrap/ToggleButton';
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -15,37 +15,37 @@ function App() {
     const [filteredCrafspeople, setFilteredCrafspeople] = useState(craftspeople);
     const [sortAlgorithm, setSortAlgorithm] = useState(() => sortByNumberOfMentees);
 
-    const filterCraftspeople = searchedValue => {
+    function filterCraftspeople(searchedValue) {
         const filteredCraftspeople = filter(craftspeople, searchedValue);
         filteredCraftspeople.sort(sortAlgorithm);
         setFilteredCrafspeople(filteredCraftspeople);
     };
 
-    const SetAndSortCraftspeople = (craftspeople) => {
+    function sortAndSetCraftspeople(craftspeople) {
         const sortedCraftspeople = craftspeople.sort(sortAlgorithm)
         setCraftsPeople(sortedCraftspeople);
         setFilteredCrafspeople(sortedCraftspeople);
     };
 
-    useEffect(() => {
-        api("craftspeople")
-            .then(data => {
-                SetAndSortCraftspeople(data);
-            })
-            .catch(error => {
-                console.log(error);
-                const fixture_data_for_craftspeople = Array.from(FIXTURE);
-                SetAndSortCraftspeople(fixture_data_for_craftspeople);
-            });
-    }, []);
-
-    const makeSortOnClickListener = (sortAlgorithmToUse) => {
+    function makeSortOnClickListener (sortAlgorithmToUse) {
         return () => {
             setSortAlgorithm(() => sortAlgorithmToUse);
             const sortedCraftspeople = filteredCrafspeople.sort(sortAlgorithmToUse);
             setFilteredCrafspeople(sortedCraftspeople);
         }
-    }
+    };
+
+    useEffect(() => {
+        api("craftspeople")
+            .then(data => {
+                sortAndSetCraftspeople(data);
+            })
+            .catch(error => {
+                console.log(error);
+                const fixture_data_for_craftspeople = Array.from(FIXTURE);
+                sortAndSetCraftspeople(fixture_data_for_craftspeople);
+            });
+    }, []);
 
     return (
         <div className='App'>

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -3,7 +3,6 @@ import "./App.css";
 import SearchBar from "./components/toolbar/SearchBar";
 import { api } from "./util/api";
 import SortableRow from "./components/list/SortableRow";
-import FIXTURE from "./util/fixture.json";
 import { sortByNumberOfMentees, sortByCraftspeopleWithoutMentor } from "./util/sorting";
 import { filter } from "./util/filtering";
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar'
@@ -11,25 +10,17 @@ import ToggleButton from 'react-bootstrap/ToggleButton';
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 
 function App() {
+    const defaultSort = sortByNumberOfMentees
+    
     const [craftspeople, setCraftsPeople] = useState([]);
     const [filteredCrafspeople, setFilteredCrafspeople] = useState(craftspeople);
-    const [sortAlgorithm, setSortAlgorithm] = useState(() => sortByNumberOfMentees);
+    const [sortAlgorithm, setSortAlgorithm] = useState(() => defaultSort);
     const [backendFetchError, setBackendFetchError] = useState(null);
-
-    function sortWithCurrentAlgorithm(craftspeople) {
-        craftspeople.sort(sortAlgorithm);
-    }
 
     function filterCraftspeople(searchedValue) {
         const filteredCraftspeople = filter(craftspeople, searchedValue);
-        sortWithCurrentAlgorithm(filteredCraftspeople);
+        craftspeople.sort(sortAlgorithm);
         setFilteredCrafspeople(filteredCraftspeople);
-    };
-
-    function sortAndSetCraftspeople(craftspeople) {
-        sortWithCurrentAlgorithm(craftspeople);
-        setCraftsPeople(craftspeople);
-        setFilteredCrafspeople(craftspeople);
     };
 
     function makeSortOnClickListener (sortAlgorithmToUse) {
@@ -43,14 +34,16 @@ function App() {
 
     useEffect(() => {
         api("craftspeople")
-            .then(data => {
-                sortAndSetCraftspeople(data);
+            .then(fetchedCraftspeople => {
+                fetchedCraftspeople.sort(defaultSort)
+                setCraftsPeople(fetchedCraftspeople);
+                setFilteredCrafspeople(fetchedCraftspeople);
             })
             .catch(error => {
                 console.log(error);
                 setBackendFetchError(error)
             });
-    }, []);
+    }, [defaultSort]);
 
     return (
         <div className='App'>

--- a/front-end/src/components/header/Header.js
+++ b/front-end/src/components/header/Header.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-export default function Header(){
-    return (
-        <h1>Mementor</h1>
-    );
-};

--- a/front-end/src/components/list/CraftspersonRow.js
+++ b/front-end/src/components/list/CraftspersonRow.js
@@ -6,7 +6,7 @@ import Button from 'react-bootstrap/Button';
 import ListGroup from 'react-bootstrap/ListGroup';
 import './Craftsperson.css'
 
-export default function SortableRow({craftsperson}) {
+export default function CraftspersonRow({craftsperson}) {
   return (
     <Accordion>
       <div className='container'>

--- a/front-end/src/components/list/CraftspersonRow.test.js
+++ b/front-end/src/components/list/CraftspersonRow.test.js
@@ -1,16 +1,15 @@
-import SortableRow from "./SortableRow";
+import CraftspersonRow from "./CraftspersonRow";
 import {render} from '@testing-library/react'
 import React from "react";
-import Craftsperson from "./Craftsperson";
 
-describe("SortableRow Component", () => {
+describe("CraftspersonRow Component", () => {
 
     it("should render with mentees", () => {
         const listOfMentees = [
             {id: 0, firstName: "Etienne", lastName: "Mustow"}, 
             {id: 1, firstName: "Arnaud", lastName: "Claudel"}, 
             {id: 2, firstName: "Naruto", lastName: "Uzumaki"}]
-        const {getByTestId} = render(<SortableRow craftsperson={{mentees: listOfMentees}} />);
+        const {getByTestId} = render(<CraftspersonRow craftsperson={{mentees: listOfMentees}} />);
 
         const getMenteeName = (index) => getByTestId('menteesList').children[index].getElementsByClassName('menteeName')[0].textContent
 


### PR DESCRIPTION
Content of the PR:

- Error message if the initial api call fails
- Empty-ish container `Header` removed
- Craftspeople are only sorted when we change the algorithm, no need to sort them for every search
- Most of the functions declared with `const` refactored in order to use `function`
  - [Why I still use javascript function statements ](https://www.freecodecamp.org/news/constant-confusion-why-i-still-use-javascript-function-statements-984ece0b72fd/)
    - If you're lazy, it's mostly for clearer intent
    - It also enables to write a function call before declaring it
- `useEffect` slighlty refactord in order to remove the dependency warning
  - [React Hooks FAQ](https://reactjs.org/docs/hooks-faq.html#is-it-safe-to-omit-functions-from-the-list-of-dependencies)
  - For this one I'm not sure if it's really better, but at least it's compliant